### PR TITLE
Next version of Ion.js

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import { init as initReceiver, receiver } from './instances/receiver'
 import { use as useMiddleware, useLast as useMiddlewareLast, run as runMiddleware } from './instances/middlewares'
 import { init as initSession, run as runSession } from './instances/sessions'
 
-const queue = new Promise(resolve => resolve())
+let queue = new Promise(resolve => resolve())
 /**
  * Initialize the bot
  * @param config the bot's configuration
@@ -31,7 +31,7 @@ export function init({ receivePort = 8080, receiveSecret, sendURL = 'http://127.
     })
     useMiddlewareLast(async ctx => runSession(ctx))
     receiver.on('post', ctx =>
-        queue.then(() => new Promise(async resolve => {
+        queue = queue.then(() => new Promise(async resolve => {
             let finished = false
             setTimeout(() => {
                 if (!finished) {

--- a/src/classes/middleware/classes.ts
+++ b/src/classes/middleware/classes.ts
@@ -1,5 +1,5 @@
 import { nextExecutor } from './utils'
-import { TMiddleware } from './definitions'
+import { IMiddleware } from './definitions'
 import Debug from 'debug'
 const debug = Debug('ionjs:middleware'),
       debugVerbose = Debug('verbose-ionjs:middleware')
@@ -7,16 +7,16 @@ const debug = Debug('ionjs:middleware'),
 /** A middleware manager */
 export class MiddlewareManager<T> {
     /** The list of middlewares */
-    private _middlewares: TMiddleware<T>[] = []
+    private _middlewares: IMiddleware<T>[] = []
     /** The list of middlewares that runs at last */
-    private _lastMiddlewares: TMiddleware<T>[] = []
+    private _lastMiddlewares: IMiddleware<T>[] = []
     /** Returns how many middlewares there are */
     get length() { return this._middlewares.length + this._lastMiddlewares.length }
     /**
      * add a middleware to the middleware list
      * @param middleware the middleware
      */
-    use(middleware: TMiddleware<T>) {
+    use(middleware: IMiddleware<T>) {
         this._middlewares = [...(this._middlewares || []), middleware]
         debug('use (+%d)', this._middlewares.length)
         return this
@@ -25,7 +25,7 @@ export class MiddlewareManager<T> {
      * add a middleware to another middleware list that'll be run at last
      * @param middleware the middleware
      */
-    useLast(middleware: TMiddleware<T>) {
+    useLast(middleware: IMiddleware<T>) {
         this._lastMiddlewares = [...(this._lastMiddlewares || []), middleware]
         debug('use last (+%d)', this._lastMiddlewares.length)
         return this

--- a/src/classes/middleware/definitions.ts
+++ b/src/classes/middleware/definitions.ts
@@ -1,1 +1,1 @@
-export type TMiddleware<T> = (ctx: T, next: () => Promise<void>) => T
+export interface IMiddleware<T> { (ctx: T, next: () => Promise<void>): T }

--- a/src/classes/middleware/index.ts
+++ b/src/classes/middleware/index.ts
@@ -1,2 +1,2 @@
 export { MiddlewareManager } from './classes'
-export { TMiddleware } from './definitions'
+export { IMiddleware } from './definitions'

--- a/src/classes/middleware/utils.ts
+++ b/src/classes/middleware/utils.ts
@@ -1,4 +1,4 @@
-import { TMiddleware } from './definitions'
+import { IMiddleware } from './definitions'
 /**
  * Generate a function that calls a function in an array,
  * records the call and pass a function that calls the next function, etc recursively
@@ -6,7 +6,7 @@ import { TMiddleware } from './definitions'
  * @param iter the iterator of the function array
  * @param context the context that'll be passed to the function
  */
-export function nextExecutor<T>(iter: IterableIterator<TMiddleware<T>>, context: any) {
+export function nextExecutor<T>(iter: IterableIterator<IMiddleware<T>>, context: any) {
     const next = iter.next().value
     return async function executeNext() {
         if (next instanceof Function)

--- a/src/classes/session/concurrent.ts
+++ b/src/classes/session/concurrent.ts
@@ -1,6 +1,6 @@
 import { SessionStore } from './base'
 import { MessageStream } from './stream'
-import { TSessionFn, TSessionMatcher, IConcurrentSessionTemplate } from './definitions'
+import { ISessionFn, ISessionMatcher, IConcurrentSessionTemplate } from './definitions'
 import Debug from 'debug'
 const debug = Debug('ionjs:session'),
       debugVerbose = Debug('verbose-ionjs:session'),
@@ -15,7 +15,7 @@ export class ConcurrentSessionManager<T> extends SessionStore<T> {
      * @param session the function for generating sessions
      * @param match determines whether the session should be created or not
      */
-    use(session: TSessionFn<T>, match: TSessionMatcher<T>) {
+    use(session: ISessionFn<T>, match: ISessionMatcher<T>) {
         const symbol = Symbol()
         this._streams.set(symbol, new Map())
         this._templates.push({ session, match, symbol })

--- a/src/classes/session/definitions.ts
+++ b/src/classes/session/definitions.ts
@@ -1,20 +1,20 @@
 import { MessageStream } from './stream'
 
-export type TSessionFn<T> = (stream: MessageStream<T>) => void
+export interface ISessionFn<T> { (stream: MessageStream<T>): void }
 
-export type TSessionMatcher<T> = (ctx: T) => boolean|Promise<boolean>
+export interface ISessionMatcher<T> { (ctx: T): boolean|Promise<boolean> }
 
 export interface ISessionTemplate<T> {
     /**
      * determines whether the session should be created or not
      * @param ctx the context
      */
-    match: TSessionMatcher<T>
+    match: ISessionMatcher<T>
     /**
      * the function for generating sessions
      * @param stream the stream for contexts matches the session id
      */
-    session: TSessionFn<T>
+    session: ISessionFn<T>
 }
 
 export interface IConcurrentSessionTemplate<T> extends ISessionTemplate<T> {

--- a/src/classes/session/index.ts
+++ b/src/classes/session/index.ts
@@ -1,4 +1,4 @@
 export { ConcurrentSessionManager } from './concurrent'
 export { SingleSessionManager } from './single'
 export { MessageStream, MessageStreamError } from './stream'
-export { TSessionFn, TSessionMatcher } from './definitions'
+export { ISessionFn, ISessionMatcher } from './definitions'

--- a/src/classes/session/single.ts
+++ b/src/classes/session/single.ts
@@ -1,6 +1,6 @@
 import { SessionStore } from './base'
 import { MessageStream } from './stream'
-import { TSessionFn, TSessionMatcher, ISingleSessionTemplate } from './definitions'
+import { ISessionFn, ISessionMatcher, ISingleSessionTemplate } from './definitions'
 import Debug from 'debug'
 const debug = Debug('ionjs:session'),
       debugVerbose = Debug('verbose-ionjs:session'),
@@ -18,7 +18,7 @@ export class SingleSessionManager<T> extends SessionStore<T> {
      *                 whether to force end the previous session (true)
      *                 or ignore this context (false or not determined)
      */
-    use(session: TSessionFn<T>, match: TSessionMatcher<T>, override: boolean = false) {
+    use(session: ISessionFn<T>, match: ISessionMatcher<T>, override: boolean = false) {
         this._templates.push({ session, match, override })
         debug('use (+%d)', this._templates.length)
         return this

--- a/src/classes/when/base.ts
+++ b/src/classes/when/base.ts
@@ -1,21 +1,21 @@
-import { TValidator, TValidatorCallback, TParser, TWhenClass } from './definitions'
+import { IValidator, IValidatorCallback, IParser, IWhenClass } from './definitions'
 
 /** A class that represents a series of conditions */
 export class When {
     /** The validators */
-    protected readonly _validators: TValidator[] = []
+    protected readonly _validators: IValidator[] = []
     /** The parsers */
-    protected readonly _parsers: TParser[] = []
+    protected readonly _parsers: IParser[] = []
     /** The validator callback (when valid) */
-    protected readonly _validCallbacks: TValidatorCallback[] = []
+    protected readonly _validCallbacks: IValidatorCallback[] = []
     /** The validator callback (when invalid) */
-    protected readonly _invalidCallbacks: TValidatorCallback[] = []
+    protected readonly _invalidCallbacks: IValidatorCallback[] = []
     /** @param fns functions for When */
     constructor({ validate = [], parse = [], validCallback = [], invalidCallback = [] }: {
-        validate?: TValidator[],
-        parse?: TParser[],
-        validCallback?: TValidatorCallback[],
-        invalidCallback?: TValidatorCallback[],
+        validate?: IValidator[],
+        parse?: IParser[],
+        validCallback?: IValidatorCallback[],
+        invalidCallback?: IValidatorCallback[],
     } = {}) {
         this._validators = validate
         this._parsers = parse
@@ -23,7 +23,7 @@ export class When {
         this._invalidCallbacks = invalidCallback
     }
     /** Returns a new When instance based on this, with one more validator and/or parser */
-    protected deriveFromType<T extends When>(derivation: { validate?: TValidator, parse?: TParser, validCallback?: TValidatorCallback, invalidCallback?: TValidatorCallback }) {
+    protected deriveFromType<T extends When>(derivation: { validate?: IValidator, parse?: IParser, validCallback?: IValidatorCallback, invalidCallback?: IValidatorCallback }) {
         const original = {
             validate: Array.from(this._validators),
             parse: Array.from(this._parsers),
@@ -37,7 +37,7 @@ export class When {
                 original[name].push(derivation[name])
             }
         }
-        return new (this.constructor as TWhenClass<T>)(original)
+        return new (this.constructor as IWhenClass<T>)(original)
     }
     /** Validate a context */
     async validate(ctx: any, ...extraArgs: any[]) {

--- a/src/classes/when/definitions.ts
+++ b/src/classes/when/definitions.ts
@@ -1,20 +1,20 @@
 import { When } from './base'
 
 /** A type alias for a validator function */
-export type TValidator<T = any> = (ctx: T, ...extraArgs: any[]) => boolean|Promise<boolean>
+export interface IValidator<T = any> { (ctx: T, ...extraArgs: any[]): boolean|Promise<boolean> }
 
 /** A type alias for a validator callback function */
-export type TValidatorCallback<T = any> = (ctx: T, ...extraArgs: any[]) => void
+export interface IValidatorCallback<T = any> { (ctx: T, ...extraArgs: any[]): void }
 
 /** A type alias for a parser function */
-export type TParser<T = any, R = any> = (ctx: T, ...extraArgs: any[]) => R|Promise<R>
+export interface IParser<T = any, R = any> { (ctx: T, ...extraArgs: any[]): R|Promise<R> }
 
 /** A type alias for class When and its derived classes */
-export type TWhenClass<T extends When> = Function&{
+export interface IWhenClass<T extends When> {
     new({ validate, parse, validCallback, invalidCallback }: {
-        validate?: TValidator[],
-        parse?: TParser[],
-        validCallback?: TValidatorCallback[],
-        invalidCallback?: TValidatorCallback[],
+        validate?: IValidator[],
+        parse?: IParser[],
+        validCallback?: IValidatorCallback[],
+        invalidCallback?: IValidatorCallback[],
     }): T
 }

--- a/src/classes/when/index.ts
+++ b/src/classes/when/index.ts
@@ -1,3 +1,3 @@
 export { When } from './base'
 export { BotWhen } from './derived'
-export { TValidator, TParser } from './definitions'
+export { IValidator, IParser } from './definitions'

--- a/src/classes/when/utils.ts
+++ b/src/classes/when/utils.ts
@@ -1,9 +1,9 @@
 import { sender } from '../../instances/sender'
 import { MessageStream } from '../session'
 import { Utils as Utils } from '../cqcode'
-import { TExtensibleMessage } from '../../instances/definitions'
+import { IExtensibleMessage } from '../../instances/definitions'
 import { escapeArgument, ICommandArguments } from '../command'
-import { TValidator } from './definitions'
+import { IValidator } from './definitions'
 
 export function compare(matcher: any, obj: any) {
     if (matcher instanceof RegExp) return matcher.test(obj)
@@ -34,11 +34,11 @@ export async function processArgs(
     { prompts, types, validators }: {
         prompts: { [param: string]: string },
         types: { [param: string]: string },
-        validators: { [param: string]: TValidator },
+        validators: { [param: string]: IValidator },
     },
     { init, stream }: {
-        init: TExtensibleMessage,
-        stream: MessageStream<TExtensibleMessage>
+        init: IExtensibleMessage,
+        stream: MessageStream<IExtensibleMessage>
     }
 ) {
     notGiven = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export {
     IModuleMetadata,
     IRegistrationMetadata,
 } from './instances/metadata'
-export { TExtensibleMessage } from './instances/definitions'
+export { IExtensibleMessage } from './instances/definitions'
 export * from './classes/sender'
 export * from './classes/receiver'
 export * from './classes/cqcode'

--- a/src/instances/definitions.ts
+++ b/src/instances/definitions.ts
@@ -1,4 +1,6 @@
 import { IMessage } from '../classes/receiver'
 
 /** IMessage that has been extended */
-export type TExtensibleMessage = IMessage&{ [x: string]: any }
+export interface IExtensibleMessage extends IMessage {
+    [x: string]: any
+}

--- a/src/instances/middlewares.ts
+++ b/src/instances/middlewares.ts
@@ -1,14 +1,14 @@
-import { MiddlewareManager, TMiddleware } from '../classes/middleware'
+import { MiddlewareManager, IMiddleware } from '../classes/middleware'
 import { IMessage } from '../classes/receiver'
-import { TExtensibleMessage } from './definitions'
+import { IExtensibleMessage } from './definitions'
 
-const manager = new MiddlewareManager<TExtensibleMessage>()
+const manager = new MiddlewareManager<IExtensibleMessage>()
 
 /**
  * Use a list of middlewares (or only one)
  * @param middlewares the middlewares
  */
-export function use(...middlewares: TMiddleware<TExtensibleMessage>[]) {
+export function use(...middlewares: IMiddleware<IExtensibleMessage>[]) {
     for (const mw of middlewares)
         manager.use(mw)
     console.log(`[INFO] ${manager.length} Middlewares loaded`)
@@ -18,7 +18,7 @@ export function use(...middlewares: TMiddleware<TExtensibleMessage>[]) {
  * Use a list of middlewares last (or only one)
  * @param middlewares the middlewares
  */
-export function useLast(...middlewares: TMiddleware<TExtensibleMessage>[]) {
+export function useLast(...middlewares: IMiddleware<IExtensibleMessage>[]) {
     for (const mw of middlewares)
         manager.useLast(mw)
     console.log(`[INFO] ${manager.length} Middlewares loaded`)


### PR DESCRIPTION
Plan:
- Make it more OO
    - For `BotWhen` & `When`, Use composing (`has-a`) instead of inheriting (`is-a`)
    - For `*SessionManager` and `SessionStore`, Use implementing (`is-an-impl-of`) instead of inheriting (`is-a`)
- Support multi `MessageStream`s in one session
- Use type aliases only when you have to do so (when you need to use calculated property names etc). These following are NOT reasons:
    - Newable object (constructor): use this
    ```ts
    interface xxx { 
        new(...) {...} 
    }
    ```
    - Callable object (function): use this
    ```ts
    interface xxx { 
        (...) { ... }
    }
    ```